### PR TITLE
Add color to output for Pokemon types (#7)

### DIFF
--- a/pokedex.py
+++ b/pokedex.py
@@ -53,8 +53,7 @@ def main():
             print(f"Type(s): {', '.join(colored_types)}")
             
         else:
-            print(f"Error: Could not find Pokémon '{pokemon_name}'")
-            print("Please check the spelling and try again.")
+            print(f"Error: Pokémon '{pokemon_name}' not found\nPlease check the spelling and try again.")
             
     except requests.exceptions.RequestException as e:
         print(f"Error: Could not connect to the PokéAPI. {e}")


### PR DESCRIPTION
## Description
This PR adds color to Pokemon types

## Type of Change
- Added color to Pokemon types on the terminal display output

## Related Issue
Fixes #(7)

## Changes Made
- Imported colorama
- Created a dictionary of Pokemon types with their colors as keys
- Created a new list of Pokemon types that are in color using the dictionary
- Printed output using the new list

## Testing
- [x] I have tested this change locally
- [x] I have run the test suite (`python test_pokedex.py`)
- [x] I have tested with multiple Pokémon names
- [x] I have tested error cases (invalid Pokémon names, no arguments)

##Additional Info
The color change only works with types Electric, Water, Fire, and Flying.
For more types, they need to be added in the 'type_colors' dictionary on line 39

